### PR TITLE
Slight cluster missile rework

### DIFF
--- a/lua/acf/shared/fuzes/cluster.lua
+++ b/lua/acf/shared/fuzes/cluster.lua
@@ -7,31 +7,33 @@ Fuze.MaxDistance = 5000
 if CLIENT then
 	Fuze.Description = "This fuze fires a beam directly ahead and releases bomblets when the beam hits something close-by. Distance in inches."
 else
-	Fuze.Spread = 15
+	Fuze.Spread = 500
 
 	function Fuze:HandleDetonation(Entity, BulletData)
 		local FillerMass = BulletData.FillerMass
-		local Bomblets   = math.Clamp(math.Round(FillerMass * 0.5), 10, 100)
+		-- Seven circles packed in a circle: https://en.wikipedia.org/wiki/Circle_packing_in_a_circle
+		local Layers     = math.Clamp(math.Round(FillerMass * 0.5 / 7), 1, 4)
+		local Bomblets   = Layers * 7
+		local Density    = 0.77778  -- Volume density of the circle packing
 		local MuzzleVec  = BulletData.Flight:GetNormalized()
 		local RoundData  = Entity.RoundData
-		local Velocity   = BulletData.Flight
 
-		BulletData.Caliber    = BulletData.Caliber / Bomblets
-		BulletData.Diameter   = BulletData.Diameter / Bomblets
+		BulletData.Caliber    = BulletData.Caliber / 3
+		BulletData.Diameter   = BulletData.Diameter / 3
 		BulletData.ProjArea   = math.pi * (BulletData.Diameter * 0.5) ^ 2
-		BulletData.ProjLength = BulletData.ProjLength / Bomblets
-		BulletData.ProjMass   = BulletData.ProjMass / Bomblets
+		BulletData.ProjLength = BulletData.ProjLength / Layers
+		BulletData.ProjMass   = BulletData.ProjMass * Density / Bomblets
 		BulletData.DragCoef   = BulletData.ProjArea * 0.0001 / BulletData.ProjMass
-		BulletData.FillerMass = FillerMass / Bomblets
+		BulletData.FillerMass = FillerMass * Density / Bomblets
 		BulletData.Tracer     = 0
 
 		if BulletData.Type == "HEAT" then
-			BulletData.SlugMass       = BulletData.SlugMass / Bomblets
-			BulletData.SlugCaliber    = BulletData.SlugCaliber / Bomblets
-			BulletData.SlugDragCoef   = BulletData.SlugDragCoef / Bomblets
-			BulletData.SlugMV         = BulletData.SlugMV / Bomblets
-			BulletData.CasingMass     = BulletData.CasingMass / Bomblets
-			BulletData.BoomFillerMass = BulletData.BoomFillerMass / Bomblets
+			BulletData.SlugMass       = BulletData.SlugMass * Density / Bomblets
+			BulletData.SlugCaliber    = BulletData.SlugCaliber * Density / Bomblets
+			BulletData.SlugDragCoef   = BulletData.SlugDragCoef * Density / Bomblets
+			BulletData.SlugMV         = BulletData.SlugMV * Density / Bomblets
+			BulletData.CasingMass     = BulletData.CasingMass * Density / Bomblets
+			BulletData.BoomFillerMass = BulletData.BoomFillerMass * Density / Bomblets
 		end
 
 		RoundData:Network(Entity, BulletData)
@@ -39,17 +41,21 @@ else
 		local Effect = EffectData()
 		Effect:SetOrigin(Entity.Position)
 		Effect:SetNormal(Entity.CurDir)
-		Effect:SetScale(math.max(FillerMass ^ 0.33 * 8 * 39.37, 1))
+		Effect:SetScale(math.max(BulletData.Caliber * 20, 1))
 		Effect:SetRadius(BulletData.Caliber)
 
 		util.Effect("ACF_Explosion", Effect)
 
-		for _ = 1, Bomblets do
-			local Cone = math.tan(math.rad(self.Spread * ACF.GunInaccuracyScale))
-			local Spread = (Entity:GetUp() * math.Rand(-1, 1) + Entity:GetRight() * math.Rand(-1, 1)):GetNormalized()
-			local ShootDir = (MuzzleVec + Cone * Spread * (math.random() ^ (1 / ACF.GunInaccuracyBias))):GetNormalized()
+		local Angle     = 0
+		local Increment = 2 * math.pi * (Layers + 1) / Layers / 7 -- Equally spaces the bomblets angle-wise
+		local Velocity  = BulletData.Flight
 
-			BulletData.Flight = ShootDir * Velocity:Length()
+		for _ = 1, Bomblets do
+			local SpreadVec = Entity:GetUp() * math.sin(Angle) + Entity:GetRight() * math.cos(Angle)
+			local SpreadVel = SpreadVec * self.Spread * math.random() ^ 0.5
+			BulletData.Flight = Velocity + SpreadVel
+
+			Angle = Angle + Increment
 
 			RoundData:Create(Entity, BulletData)
 		end

--- a/lua/acf/shared/fuzes/cluster.lua
+++ b/lua/acf/shared/fuzes/cluster.lua
@@ -15,7 +15,6 @@ else
 		local Layers     = math.Clamp(math.Round(FillerMass * 0.5 / 7), 1, 4)
 		local Bomblets   = Layers * 7
 		local Density    = 0.77778  -- Volume density of the circle packing
-		local MuzzleVec  = BulletData.Flight:GetNormalized()
 		local RoundData  = Entity.RoundData
 
 		BulletData.Caliber    = BulletData.Caliber / 3


### PR DESCRIPTION
Slightly reworked cluster missiles so that the bomblets are properly modeled. It assumes 7 are packed in parallel per layer, with up to 4 layers, resulting in a maximum of 28 bomblets. The bomblet caliber and length is changed to reflect this. For any questions refer to [https://en.wikipedia.org/wiki/Circle_packing_in_a_circle](url)

The random spread is also significantly simplified by using a uniform angle distribution, randomizing only the distance from the center. It results in almost the same spread, only slightly more uniform:

![image](https://user-images.githubusercontent.com/37046867/114117186-06d95480-98de-11eb-839b-e29b93cc750e.png)

Removed the relationship between bomblet spread and global inaccuracy, as it seemed a bit nonsensical (you essentially want the bomblets to be "inaccurate").

Physics-wise, it also makes more sense, with the bomblets gaining a velocity perpendicular to the deployer which is independent of it's original velocity. They now inherit the original velocity plus the separation velocity, instead of changing vector's the direction.