### PR TITLE
Fix lua error

### DIFF
--- a/lua/entities/acf_missile/init.lua
+++ b/lua/entities/acf_missile/init.lua
@@ -616,7 +616,9 @@ function ENT:Detonate(Destroyed)
 		return Fuze:HandleDetonation(self, BulletData)
 	end
 
-	Debug.Line(BulletData.Pos, BulletData.Pos + BulletData.Flight, 10, Color(255, 128, 0))
+	if BulletData.Pos then
+		Debug.Line(BulletData.Pos, BulletData.Pos + BulletData.Flight, 10, Color(255, 128, 0))
+	end
 
 	BulletData.DetonatorAngle = 91
 


### PR DESCRIPTION
Fixes:
```
[[ACF] Armored Combat Framework: Missiles Extension] lua/entities/acf_missile/init.lua:617: attempt to perform arithmetic on field 'Pos' (a nil value)
1. Detonate - lua/entities/acf_missile/init.lua:617
 2. DetonateMissile - lua/entities/acf_missile/init.lua:300
  3. ACF_OnDamage - lua/entities/acf_missile/init.lua:708
   4. dealDamage - lua/acf/damage/damage_sv.lua:254
    5. createExplosion - lua/acf/damage/explosion_sv.lua:179
     6. OnFlightEnd - lua/acf/entities/ammo_types/aphe.lua:133
      7. OnImpact - lua/acf/ballistics/ballistics_sv.lua:197
       8. DoBulletsFlight - lua/acf/ballistics/ballistics_sv.lua:293
        9. CalcBulletFlight - lua/acf/ballistics/ballistics_sv.lua:81
         10. func - lua/acf/ballistics/ballistics_sv.lua:111
          11. internal_call - lua/includes/modules/hook.lua:409
           12. Run - lua/includes/modules/hook.lua:428
            13. func - lua/acf/core/utilities/clock/clock.lua:13
             14. internal_call - lua/includes/modules/hook.lua:409
              15. unknown - lua/includes/modules/hook.lua:428
```
Maybe the cause of the problem is deeper, but Pos is used for debug information that is not used in regular play